### PR TITLE
🐞 fix(#74): GTM ID 直接記述に変更

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -21,7 +21,6 @@ interface Props {
 }
 
 const { blog } = Astro.props;
-const gtmId = import.meta.env.GTM_ID;
 const author = member.find(m => m.name === blog.data.author);
 const title = `${blog.data.title} | ${siteInfo.appName}`;
 const description = blog.data.description || siteInfo.description;
@@ -69,7 +68,7 @@ const authorX = author?.links?.find(l => l.name === 'X')?.id;
     <!-- Google Tag Manager -->
     <script
       type="text/partytown"
-      src=`https://www.googletagmanager.com/gtag/js?id=${gtmId}`
+      src="https://www.googletagmanager.com/gtag/js?id=GTM-5FTGXC87"
       is:inline></script>
     <script type="text/partytown" is:inline>
       window.dataLayer = window.dataLayer || [];
@@ -77,7 +76,7 @@ const authorX = author?.links?.find(l => l.name === 'X')?.id;
         dataLayer.push(arguments);
       }
       gtag('js', new Date());
-      gtag('config', `${gtmId}`);
+      gtag('config', 'GTM-5FTGXC87');
     </script>
     <!-- End Google Tag Manager -->
   </head>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,7 +13,6 @@ interface Props {
 }
 
 const { title, description, author } = Astro.props;
-const gtmId = import.meta.env.GTM_ID;
 const meta = {
   title: title ? `${title} | ${siteInfo.appName}` : siteInfo.appName,
   description: description || siteInfo.description,
@@ -62,7 +61,7 @@ const meta = {
     <!-- Google Tag Manager -->
     <script
       type="text/partytown"
-      src=`https://www.googletagmanager.com/gtag/js?id=${gtmId}`
+      src="https://www.googletagmanager.com/gtag/js?id=GTM-5FTGXC87"
       is:inline></script>
     <script type="text/partytown" is:inline>
       window.dataLayer = window.dataLayer || [];
@@ -70,7 +69,7 @@ const meta = {
         dataLayer.push(arguments);
       }
       gtag('js', new Date());
-      gtag('config', `${gtmId}`);
+      gtag('config', 'GTM-5FTGXC87');
     </script>
     <!-- End Google Tag Manager -->
   </head>


### PR DESCRIPTION
This pull request includes changes to the Google Tag Manager (GTM) implementation in two layout files, `BlogLayout.astro` and `Layout.astro`. The GTM ID is now hardcoded instead of being dynamically imported from environment variables.

Changes to GTM implementation:

* [`src/layouts/BlogLayout.astro`](diffhunk://#diff-c3f0ff783e91eb7167bc4e0c2bfec7726f9f1a6842ac62138661ff9ffef37532L24): Removed the dynamic import of the GTM ID and replaced it with a hardcoded value in the script tags. [[1]](diffhunk://#diff-c3f0ff783e91eb7167bc4e0c2bfec7726f9f1a6842ac62138661ff9ffef37532L24) [[2]](diffhunk://#diff-c3f0ff783e91eb7167bc4e0c2bfec7726f9f1a6842ac62138661ff9ffef37532L72-R79)
* [`src/layouts/Layout.astro`](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L16): Similarly, removed the dynamic import of the GTM ID and replaced it with a hardcoded value in the script tags. [[1]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L16) [[2]](diffhunk://#diff-ba00f1d7bc63648f0861e03d786d6f1ed78307f1b40284e4db329586d3df2db2L65-R72)

fix #74 