### PR TITLE
🐞 fix(#86): link word-break

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -11,7 +11,7 @@ import { Badge } from '@/components/ui/badge';
 import '@/styles/globals.css';
 import member from '@/data/member';
 import MemberCard from '@/components/MemberCard.astro';
-import { type CollectionEntry } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
 import { SEO } from 'astro-seo';
 import Share from '@/components/Share.astro';
 import Social from '@/components/Social.astro';
@@ -252,6 +252,7 @@ const authorX = author?.links?.find(l => l.name === 'X')?.id;
 
         a {
           text-decoration: underline;
+          word-break: break-all;
         }
 
         pre {


### PR DESCRIPTION
This pull request includes minor changes to the `BlogLayout.astro` file, focusing on code style adjustments and CSS improvements.

Code style adjustments:
* Changed the import statement for `CollectionEntry` to use `type` syntax for better clarity and adherence to TypeScript conventions. (`[src/layouts/BlogLayout.astroL14-R14](diffhunk://#diff-c3f0ff783e91eb7167bc4e0c2bfec7726f9f1a6842ac62138661ff9ffef37532L14-R14)`)

CSS improvements:
* Added `word-break: break-all;` to anchor (`a`) tags to improve text wrapping behavior in the layout. (`[src/layouts/BlogLayout.astroR255](diffhunk://#diff-c3f0ff783e91eb7167bc4e0c2bfec7726f9f1a6842ac62138661ff9ffef37532R255)`)